### PR TITLE
PBI-105415: Setup logging to central elastic search instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # tfmodule-azure-elastic-eventhub-logging
 Use this module to create an eventhub with an associated Elastic Azure Log Integration. 
-It 
+
+*NOTE: Currently the Data View must be created manually...*
+
+After this has been run the Elastic policy and data stream will be created.  To create an Elastic Data View using the new data stream you must first push logs to the event hub.  Then the data stream will appear when setting the index pattern for the new Data View.
 
 ## Requirements
 - `Service` Pass in a service name for the service you want to log. To manage multiple services create multiple references to the module (see usage). 
@@ -33,7 +36,7 @@ module "logging" {
   elk_storage_account                   = var.elk_storage_account
   elk_storage_account_key               = var.elk_storage_account_key
   elk_namespace                         = var.elk_namespace # must be lower case 
-
+  using_serilog                         = false # Adds expected keys if set to true and using Serilog, if using UKHO EventHub-Logging-Provider package set it to false
 
   depends_on = []
   count      = var.enable_evhns ? 1 : 0

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # tfmodule-azure-elastic-eventhub-logging
-Use this module to create an eventhub with an associated Elastic Azure Log Intergration. 
+Use this module to create an eventhub with an associated Elastic Azure Log Integration. 
 It 
 
-## Requirments
-- `Sercice` Pass in a service name for the service you want to log. To manage multiple services create multiple refrences to the module (see usage). 
+## Requirements
+- `Service` Pass in a service name for the service you want to log. To manage multiple services create multiple references to the module (see usage). 
 - `EventHubNameSpace` This module requires an eventhub namespace to be created in your terraform before the module can be called. Ensure you have a depends on within the module to your EventHub Namespace.
 - `Azure App Configuration` The module will create two keys in AAC `<service>:EventHubLogging:EntityPath` and `<service::EventHubLogging:EntityPath>`. These are then used to push configure your service to log to the required EventHub.
 - `Elastc API Key` You require an API Key with fleet manage permissions to interact with Elastic. 
@@ -11,7 +11,7 @@ It
 
 
 ## Usage 
-Create a new file in your terrafrom repository with naming matching `<service>-api-logging.tf` This allows multiple sercices within your IaC to use the module from your repository as required. 
+Create a new file in your terraform repository with naming matching `<service>-api-logging.tf` This allows multiple services within your IaC to use the module from your repository as required. 
 
 ```
 module "logging" {
@@ -26,7 +26,6 @@ module "logging" {
   location                              = var.location
   resource_group_name                   = ""
   configuration_store_id                = azurerm_app_configuration.data_hub_appConfig.id
-  #event_hub_namespace_connection_string = azurerm_eventhub_namespace.this.default_primary_connection_string
   event_hub_namespace                   = azurerm_eventhub_namespace.this.name
   agent_policy_id                       = var.agent_policy_id
   elk_api_key                           = var.elastic_api_key

--- a/azure-app-config.tf
+++ b/azure-app-config.tf
@@ -1,6 +1,7 @@
 
 
 resource "azurerm_app_configuration_key" "eventhub_logging_entitypath" {
+  count           = (var.using_serilog == false) ? 1 : 0
   configuration_store_id = var.configuration_store_id
   key                    = "${var.service}:EventHubLogging:EntityPath"
   value                   = azurerm_eventhub.logging.name
@@ -8,6 +9,7 @@ resource "azurerm_app_configuration_key" "eventhub_logging_entitypath" {
 }
 
 resource "azurerm_app_configuration_key" "eventhub_logging_environment" {
+  count           = (var.using_serilog == false) ? 1 : 0
   configuration_store_id = var.configuration_store_id
   key                    = "${var.service}:EventHubLogging:Environment"
   value                   = upper(var.env)
@@ -15,6 +17,7 @@ resource "azurerm_app_configuration_key" "eventhub_logging_environment" {
 }
 
 resource "azurerm_app_configuration_key" "eventhub_logging_level" {
+  count           = (var.using_serilog == false) ? 1 : 0
   configuration_store_id = var.configuration_store_id
   key                    = "${var.service}:EventHubLogging:MinimumLoggingLevel"
   value                   = var.svc_min_log_level
@@ -22,6 +25,7 @@ resource "azurerm_app_configuration_key" "eventhub_logging_level" {
 }
 
 resource "azurerm_app_configuration_key" "eventhub_logging_ukho_level" {
+  count           = (var.using_serilog == false) ? 1 : 0
   configuration_store_id = var.configuration_store_id
   key                    = "${var.service}:EventHubLogging:UkhoMinimumLoggingLevel"
   value                   = var.ukho_min_log_level
@@ -29,6 +33,7 @@ resource "azurerm_app_configuration_key" "eventhub_logging_ukho_level" {
 }
 
 resource "azurerm_app_configuration_key" "serilog_logging_environment" {
+  count           = (var.using_serilog == true) ? 1 : 0
   configuration_store_id = var.configuration_store_id
   key                    = "${var.service}:Serilog:Properties:_Environment"
   value                   = upper(var.env)
@@ -36,6 +41,7 @@ resource "azurerm_app_configuration_key" "serilog_logging_environment" {
 }
 
 resource "azurerm_app_configuration_key" "serilog_logging_entitypath" {
+  count           = (var.using_serilog == true) ? 1 : 0
   configuration_store_id = var.configuration_store_id
   key                    = "${var.service}:Logging:EventHub:EntityPath"
   value                   = azurerm_eventhub.logging.name

--- a/azure-app-config.tf
+++ b/azure-app-config.tf
@@ -33,7 +33,7 @@ resource "azurerm_app_configuration_key" "eventhub_logging_ukho_level" {
 }
 
 resource "azurerm_app_configuration_key" "serilog_logging_environment" {
-  count           = (var.using_serilog == true) ? 1 : 0
+  count           = var.using_serilog ? 1 : 0
   configuration_store_id = var.configuration_store_id
   key                    = "${var.service}:Serilog:Properties:_Environment"
   value                   = upper(var.env)
@@ -41,7 +41,7 @@ resource "azurerm_app_configuration_key" "serilog_logging_environment" {
 }
 
 resource "azurerm_app_configuration_key" "serilog_logging_entitypath" {
-  count           = (var.using_serilog == true) ? 1 : 0
+  count           = var.using_serilog ? 1 : 0
   configuration_store_id = var.configuration_store_id
   key                    = "${var.service}:Logging:EventHub:EntityPath"
   value                   = azurerm_eventhub.logging.name

--- a/azure-app-config.tf
+++ b/azure-app-config.tf
@@ -27,3 +27,17 @@ resource "azurerm_app_configuration_key" "eventhub_logging_ukho_level" {
   value                   = var.ukho_min_log_level
   lifecycle { ignore_changes = [ value, tags, configuration_store_id ] }
 }
+
+resource "azurerm_app_configuration_key" "serilog_logging_environment" {
+  configuration_store_id = var.configuration_store_id
+  key                    = "${var.service}:Serilog:Properties:_Environment"
+  value                   = upper(var.env)
+  lifecycle { ignore_changes = [ value, tags, configuration_store_id ] }
+}
+
+resource "azurerm_app_configuration_key" "serilog_logging_entitypath" {
+  configuration_store_id = var.configuration_store_id
+  key                    = "${var.service}:Logging:EventHub:EntityPath"
+  value                   = azurerm_eventhub.logging.name
+  lifecycle { ignore_changes = [ value, tags, configuration_store_id ] }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,8 +30,6 @@ variable "resource_group_name" {
 
 variable "event_hub_namespace" {}
 
-#variable "event_hub_namespace_connection_string" {}
-
 variable "configuration_store_id" {}
 
 variable "agent_policy_id" {}

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,9 @@ variable "elk_namespace" {} # must be lower case
 variable "svc_min_log_level" {}
 
 variable "ukho_min_log_level" {}
+
+variable "using_serilog" {
+  type = bool
+  description = "Adds expected keys if using Serilog, if using UKHO EventHub-Logging-Provider package exclude or set false"
+  default = false
+}


### PR DESCRIPTION
What

Configure BDBImporter service to log to Elastic Cloud via Event Hub per environment.

Why

As developers we need access to logs in order to test/debug/support our applications. 

How

Deploy an Event Hub and create an Elastic Azure Logs Integration and Data View in each environment using the terraform module created in PBI:
Product Backlog Item 104075 Terraform Event Hub Elastic Logging Module (azure.com)

Dev, Staging and QA environments should be integrated with the non live elastic instance
Services - APM - Observability - Elastic (elastic-cloud.com)

The Live environment should be integrated with the live elastic instance.
ukho.es.uksouth.azure.elastic-cloud.com

Use Serilog with the Azure EventHub Sink. Use the shared serilog enrichment package if appropriate enrichers are available.
UKHO/UKHO.Logging.Serilog: UKHO shared logging when using Serilog (github.com)
Enrichment may be limited to assembly information as this service runs as a cronjob, it has no http context or elastic integration.

For an example see
UKHO.Logging.Serilog/UKHO.Logging.Serilog.SampleAspNetCoreWebApi at main · UKHO/UKHO.Logging.Serilog (github.com)

https://dev.azure.com/ukhydro/Data%20Platform/_workitems/edit/105415

AB#105415