### PR TITLE
Replacement of deprecated namespace_name, resource_group_name. Now us…

### DIFF
--- a/eventhub.tf
+++ b/eventhub.tf
@@ -1,7 +1,6 @@
 resource "azurerm_eventhub" "logging" {
   name                = "${var.product_alias}-${var.service}-${var.env}-evh"
-  namespace_name      = var.event_hub_namespace
-  resource_group_name = var.resource_group_name
+  namespace_id        = var.event_hub_namespace_id
   partition_count     = 2
   message_retention   = 1
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,10 @@ variable "resource_group_name" {
 
 variable "event_hub_namespace" {}
 
+variable "event_hub_namespace_id" {
+  description = "The resource ID of the Event Hub Namespace"
+}
+
 variable "configuration_store_id" {}
 
 variable "svc_min_log_level" {}


### PR DESCRIPTION
This pull request updates the configuration for Azure Event Hub resources to improve how the Event Hub namespace is referenced. The main change is switching from using the namespace name and resource group name to using the namespace resource ID directly, which is a more robust and future-proof approach.

**Infrastructure changes:**

* Updated the `azurerm_eventhub` resource in `eventhub.tf` to use `namespace_id` instead of `namespace_name` and `resource_group_name`, aligning with best practices for referencing Azure resources.

**Variable management:**

* Added a new variable `event_hub_namespace_id` in `variables.tf` to store the resource ID of the Event Hub Namespace, and updated documentation for clarity.